### PR TITLE
Include Elasticsearch service in the OpenShift deployment

### DIFF
--- a/src/main/java/io/quarkus/search/app/indexing/IndexingConfig.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.search.app.indexing;
+
+import java.time.Duration;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "indexing")
+interface IndexingConfig {
+    OnStartup onStartup();
+
+    interface OnStartup {
+        @WithDefault("true")
+        boolean enabled();
+
+        @WithDefault("3s")
+        Duration waitInterval();
+    }
+}

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
@@ -35,7 +36,10 @@ public class IndexingService {
 
     void registerManagementRoutes(@Observes ManagementInterface mi) {
         mi.router().get("/reindex")
-                .blockingHandler(rc -> reindex());
+                .blockingHandler(rc -> {
+                    reindex();
+                    rc.end("Success");
+                });
     }
 
     void indexOnStartup(@Observes StartupEvent ev,
@@ -45,7 +49,8 @@ public class IndexingService {
         }
     }
 
-    private void reindex() {
+    @ActivateRequestContext
+    protected void reindex() {
         clearIndexes();
         indexAll();
     }

--- a/src/main/kubernetes/openshift.yml
+++ b/src/main/kubernetes/openshift.yml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  labels:
+    app: elasticsearch
+    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/component: datastore
+    app.kubernetes.io/part-of: search-quarkus-io
+    app.kubernetes.io/managed-by: quarkus
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 9200
+  selector:
+    app.kubernetes.io/name: elasticsearch
+  type: ClusterIP
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: elasticsearch
+  labels:
+    app: elasticsearch
+    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/component: datastore
+    app.kubernetes.io/part-of: search-quarkus-io
+    app.kubernetes.io/managed-by: quarkus
+spec:
+  replicas: 3
+  selector:
+    app.kubernetes.io/name: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+        app.kubernetes.io/name: elasticsearch
+        app.kubernetes.io/component: datastore
+        app.kubernetes.io/part-of: search-quarkus-io
+        app.kubernetes.io/managed-by: quarkus
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 500Mi
+          env:
+            - name: cluster.name
+              value: search-quarkus-io
+            # Not exposed to the internet, no sensitive data
+            # => We don't bother with HTTPS and pesky self-signed certificates
+            - name: xpack.security.enabled
+              value: false
+          envFrom:
+            - configMapRef:
+                name: elasticsearch-config
+            - secretRef:
+                name: elasticsearch-secrets
+          ports:
+            - containerPort: 9200
+              name: http
+              protocol: TCP

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,14 @@ quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.title=Quarkus Search API
 
 # Production
+## This should match the Elasticsearch service defined in src/main/kubernetes
+## We assume the cluster DNS will resolve the service name to the service IP automatically
+%prod.quarkus.hibernate-search-orm.elasticsearch.hosts=elasticsearch:80
+%prod.quarkus.hibernate-search-orm.elasticsearch.protocol=http
+## We don't expect Elasticsearch to be reachable when the application starts
+%prod.quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false
+## ... and the application automatically creates indexes upon first indexing anyway.
+%prod.quarkus.hibernate-search-orm.schema-management.strategy=none
 
 # Deployment to OpenShift
 %prod.quarkus.openshift.labels."app"=search.quarkus.io


### PR DESCRIPTION
Taking advantage of https://quarkus.io/guides/deploying-to-kubernetes#using-existing-resources